### PR TITLE
hotfix: error message when sending

### DIFF
--- a/src/FundsTransfer.js
+++ b/src/FundsTransfer.js
@@ -297,7 +297,7 @@ class FundsTransfer extends Component {
           err = JSON.parse(err);
           console.log(err);
           err = JSON.parse(err.error);
-          throw Errors.sendFail + err;
+          throw Errors.sendFail + err.error.message;
         } else {
           throw Errors.networkError;
         }

--- a/src/Networks.js
+++ b/src/Networks.js
@@ -258,8 +258,8 @@ const networks = {
     bitcoinjs: {
       messagePrefix: "Zcash Signed Message:",
       bip32: { public: 76067358, private: 87393172 },
-      pubKeyHash: 7352,
-      scriptHash: 7357,
+      pubKeyHash: new Uint8Array([0x1c, 0xb8]) /*7352*/,
+      scriptHash: new Uint8Array([0x1c, 0xbd]) /*7357*/,
       wif: 128
     },
     isSegwitSupported: false,


### PR DESCRIPTION
Properly display error's message instead of [object Object]