### PR TITLE
Updated Stratis Extended Pub Key prefix

### DIFF
--- a/src/Networks.js
+++ b/src/Networks.js
@@ -229,7 +229,7 @@ const networks = {
     apiName: "strat",
     bitcoinjs: {
       messagePrefix: "Stratis Signed Message:",
-      bip32: { public: 76071454, private: 87393172 },
+      bip32: { public: 76067358, private: 76066276 },
       pubKeyHash: 63,
       scriptHash: 125,
       wif: 128


### PR DESCRIPTION
The goal of this PR is to update the values of Stratis' Extended Public and Private Key prefixes in Ledger applications, in order for them to be in line with the ones from Stratis' code.

At the moment, Ledger applications have the following values for Stratis' Extended Public and Private Key prefixes:
0x0488C21E/76071454 for ExtPubKey
0x0488B2DD/87393172 for ExtPrivKey.

Stratis' BIP44 compatible wallet uses different values for these prefixes.
The values in use are the same as Bitcoin:
0x0488B21E/76067358 for ExtPubKey
0x0488ADE4/76066276 for ExtPrivKey

See here: https://github.com/stratisproject/StratisBitcoinFullNode/blob/master/src/NBitcoin/Networks.cs#L425
