### PR TITLE
Automatically update path when coin is selected.

### DIFF
--- a/src/BalanceChecker.js
+++ b/src/BalanceChecker.js
@@ -116,7 +116,10 @@ class BalanceChecker extends Component {
 
   handleChangeCoin = e => {
     this.reset();
-    this.setState({ coin: e.target.value });
+    this.setState({ 
+      coin: e.target.value,
+      path: `44'/${e.target.value}'/0'`
+    });
   };
 
   onUpdate = (e, i, j) => {
@@ -321,6 +324,7 @@ class BalanceChecker extends Component {
     }
 
     return (
+      
       <div className="BalanceChecker">
         <form onSubmit={this.recover}>
           <FormGroup controlId="BalanceChecker">


### PR DESCRIPTION
The Check Balances page lets you select the coin on the dropdown but it wasn't automatically updating the Path to that of the selected coin.  e.g. stratis 44'/105'/0'   - So this PR is to automatically update that path on the UI when dropdown change.